### PR TITLE
[MP] Fix disconnect_peer not doing the proper cleanup

### DIFF
--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -425,11 +425,11 @@ void SceneMultiplayer::_del_peer(int p_id) {
 
 void SceneMultiplayer::disconnect_peer(int p_id) {
 	ERR_FAIL_COND(multiplayer_peer.is_null() || multiplayer_peer->get_connection_status() != MultiplayerPeer::CONNECTION_CONNECTED);
-	if (pending_peers.has(p_id)) {
-		pending_peers.erase(p_id);
-	} else if (connected_peers.has(p_id)) {
-		connected_peers.erase(p_id);
-	}
+	// Block signals to avoid emitting peer_disconnected.
+	bool blocking = is_blocking_signals();
+	set_block_signals(true);
+	_del_peer(p_id);
+	set_block_signals(blocking);
 	multiplayer_peer->disconnect_peer(p_id);
 }
 


### PR DESCRIPTION
Lower layers (cache, replication) were not being notified about the peer being disconnected.

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
